### PR TITLE
Improve imbalance handling and edge weighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ We provide a quick overview of how to use our package for analyzing traffic acci
 from ml_for_road_safety import TrafficAccidentDataset
 
 # Creating the dataset as PyTorch Geometric dataset object
-dataset = TrafficAccidentDataset(state_name = "MA")
+# The ``neg_pos_ratio`` option controls the number of negative samples per positive edge
+dataset = TrafficAccidentDataset(state_name="MA", neg_pos_ratio=1.0)
 
 # Loading the accident records and traffic network features of a particular month
 data = dataset.load_monthly_data(year = 2022, month = 1)

--- a/ml_for_road_safety/train.py
+++ b/ml_for_road_safety/train.py
@@ -26,9 +26,11 @@ def main(args):
                                use_dynamic_node_features=args.load_dynamic_node_features,
                                use_dynamic_edge_features=args.load_dynamic_edge_features,
                                train_years=args.train_years,
-                               num_negative_edges=args.num_negative_edges) 
+                               num_negative_edges=args.num_negative_edges,
+                               neg_pos_ratio=args.neg_pos_ratio)
     task_type = "regression" if (args.train_accident_regression or args.train_volume_regression) else "classification"
-    evaluator = Evaluator(type=task_type)
+    evaluator = Evaluator(type=task_type, loss_type=args.loss_type,
+                          pos_weight=args.pos_weight, focal_gamma=args.focal_gamma)
     
     data = dataset.data
     in_channels_node = data.x.shape[1] if data.x is not None else 0
@@ -170,6 +172,7 @@ if __name__ == "__main__":
 
     parser.add_argument('--state_name', type=str, default="MA")
     parser.add_argument('--num_negative_edges', type=int, default=100000000)
+    parser.add_argument('--neg_pos_ratio', type=float, default=None)
 
     parser.add_argument('--device', type=int, default=0)
     parser.add_argument('--log_steps', type=int, default=1)
@@ -190,6 +193,9 @@ if __name__ == "__main__":
     parser.add_argument('--epochs', type=int, default=1)
     parser.add_argument('--eval_steps', type=int, default=5)
     parser.add_argument('--runs', type=int, default=1)
+    parser.add_argument('--loss_type', type=str, default='bce', choices=['bce','weighted_bce','focal'])
+    parser.add_argument('--pos_weight', type=float, default=1.0)
+    parser.add_argument('--focal_gamma', type=float, default=2.0)
 
     parser.add_argument('--train_years', nargs='+', type=int, default=[2002])
     parser.add_argument('--valid_years', nargs='+', type=int, default=[2003])

--- a/ml_for_road_safety/utils/losses.py
+++ b/ml_for_road_safety/utils/losses.py
@@ -1,0 +1,9 @@
+import torch
+import torch.nn.functional as F
+
+def focal_loss(input, target, gamma=2.0, weight=None):
+    """Compute focal loss for binary classification."""
+    bce = F.binary_cross_entropy(input, target, reduction="none", weight=weight)
+    p_t = input * target + (1 - input) * (1 - target)
+    loss = (1 - p_t) ** gamma * bce
+    return loss.mean()


### PR DESCRIPTION
## Summary
- add focal loss utility and extend `Evaluator` to handle weighted BCE and focal loss
- allow configuring negative to positive sampling ratio in `TrafficAccidentDataset`
- compute per-edge weights from length, traffic and accident history
- pass edge weights through GNN layers
- support weighted losses in trainers
- expose `neg_pos_ratio` and new loss options in CLI
- document sampling ratio option in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853c30edbfc832e8fca7698ad487325