### PR TITLE
Remove monthly_data logging

### DIFF
--- a/ml_for_road_safety/trainers/trainer.py
+++ b/ml_for_road_safety/trainers/trainer.py
@@ -40,8 +40,6 @@ class Trainer:
 
     def train_on_month_data(self, year, month): 
         monthly_data = self.dataset.load_monthly_data(year, month)
-        with open("monthly_data.txt", "w") as f:
-            pprint.pprint(monthly_data, stream=f, indent=4, width=120)
 
         # load previous months 
         if self.use_time_series:


### PR DESCRIPTION
## Summary
- remove debug code writing `monthly_data.txt` when training

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685419792318832e995e1edd98b297ff