### PR TITLE
Fix negative edge attribute mapping

### DIFF
--- a/ml_for_road_safety/trainers/sam_trainer.py
+++ b/ml_for_road_safety/trainers/sam_trainer.py
@@ -37,6 +37,7 @@ class SAMTrainer(Trainer):
         new_data = monthly_data['data']
         pos_edges, pos_edge_weights, neg_edges = \
             monthly_data['accidents'], monthly_data['accident_counts'], monthly_data['neg_edges']
+        neg_edge_ids = monthly_data.get('neg_edge_ids')
         
         if pos_edges is None or pos_edges.size(0) < 10:
             return 0, 0
@@ -65,6 +66,10 @@ class SAMTrainer(Trainer):
         pos_train_edge = pos_edges.to(self.device)
         pos_edge_weights = pos_edge_weights.to(self.device)
         neg_edges = neg_edges.to(self.device)
+        if neg_edge_ids is not None:
+            neg_edge_ids = neg_edge_ids.to(self.device)
+        if neg_edge_ids is not None:
+            neg_edge_ids = neg_edge_ids.to(self.device)
         total_loss = total_examples = 0
         # self.batch_size > pos_train_edge.size(0): only backprop once since it does not retain cache.
         for perm in DataLoader(range(pos_train_edge.size(0)), self.batch_size, shuffle=True):
@@ -77,10 +82,14 @@ class SAMTrainer(Trainer):
 
             # sampling from negative edges
             neg_masks = np.random.choice(neg_edges.size(0), min(edge.size(1), neg_edges.size(0)), replace=False)
-            edge = neg_edges[neg_masks].t() # torch.randint(0, x.size(0), edge.size(), dtype=torch.long, device=device)
+            edge = neg_edges[neg_masks].t()
+            if neg_edge_ids is not None:
+                neg_id = neg_edge_ids[neg_masks]
+            else:
+                neg_id = perm[:edge.size(1)]
             neg_out = self.predictor(h[edge[0]], h[edge[1]]) \
                 if edge_attr is None else \
-                self.predictor(h[edge[0]], h[edge[1]], edge_attr[perm])
+                self.predictor(h[edge[0]], h[edge[1]], edge_attr[neg_id])
             
             labels = torch.cat([torch.ones(pos_out.size(0)), torch.zeros(neg_out.size(0))]).view(-1, 1).to(self.device)
             weight = torch.ones_like(labels)
@@ -124,10 +133,14 @@ class SAMTrainer(Trainer):
 
             # sampling from negative edges
             neg_masks = np.random.choice(neg_edges.size(0), min(edge.size(1), neg_edges.size(0)), replace=False)
-            edge = neg_edges[neg_masks].t() # torch.randint(0, x.size(0), edge.size(), dtype=torch.long, device=device)
+            edge = neg_edges[neg_masks].t()
+            if neg_edge_ids is not None:
+                neg_id = neg_edge_ids[neg_masks]
+            else:
+                neg_id = perm[:edge.size(1)]
             neg_out = self.predictor(h[edge[0]], h[edge[1]]) \
                 if edge_attr is None else \
-                self.predictor(h[edge[0]], h[edge[1]], edge_attr[perm])
+                self.predictor(h[edge[0]], h[edge[1]], edge_attr[neg_id])
             
             labels = torch.cat([torch.ones(pos_out.size(0)), torch.zeros(neg_out.size(0))]).view(-1, 1).to(self.device)
             weight = torch.ones_like(labels)


### PR DESCRIPTION
## Summary
- build `edge_id_map` for quick lookup of edge indices
- record `pos_edge_ids` and `neg_edge_ids` in monthly data
- index edge attributes for negative samples in Trainer, SAMTrainer and SupConTrainer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854197f1eb4832ea7f1ea02fcd46bde