### PR TITLE
Fix edge attribute indexing in trainers

### DIFF
--- a/ml_for_road_safety/trainers/sam_trainer.py
+++ b/ml_for_road_safety/trainers/sam_trainer.py
@@ -37,6 +37,7 @@ class SAMTrainer(Trainer):
         new_data = monthly_data['data']
         pos_edges, pos_edge_weights, neg_edges = \
             monthly_data['accidents'], monthly_data['accident_counts'], monthly_data['neg_edges']
+        pos_edge_ids = monthly_data.get('pos_edge_ids')
         neg_edge_ids = monthly_data.get('neg_edge_ids')
         
         if pos_edges is None or pos_edges.size(0) < 10:
@@ -66,8 +67,8 @@ class SAMTrainer(Trainer):
         pos_train_edge = pos_edges.to(self.device)
         pos_edge_weights = pos_edge_weights.to(self.device)
         neg_edges = neg_edges.to(self.device)
-        if neg_edge_ids is not None:
-            neg_edge_ids = neg_edge_ids.to(self.device)
+        if pos_edge_ids is not None:
+            pos_edge_ids = pos_edge_ids.to(self.device)
         if neg_edge_ids is not None:
             neg_edge_ids = neg_edge_ids.to(self.device)
         total_loss = total_examples = 0
@@ -78,7 +79,7 @@ class SAMTrainer(Trainer):
             edge = pos_train_edge[perm].t()
             pos_out = self.predictor(h[edge[0]], h[edge[1]]) \
                 if edge_attr is None else \
-                self.predictor(h[edge[0]], h[edge[1]], edge_attr[perm])
+                self.predictor(h[edge[0]], h[edge[1]], edge_attr[pos_edge_ids[perm] if pos_edge_ids is not None else perm])
 
             # sampling from negative edges
             neg_masks = np.random.choice(neg_edges.size(0), min(edge.size(1), neg_edges.size(0)), replace=False)
@@ -129,7 +130,7 @@ class SAMTrainer(Trainer):
             edge = pos_train_edge[perm].t()
             pos_out = self.predictor(h[edge[0]], h[edge[1]]) \
                 if edge_attr is None else \
-                self.predictor(h[edge[0]], h[edge[1]], edge_attr[perm])
+                self.predictor(h[edge[0]], h[edge[1]], edge_attr[pos_edge_ids[perm] if pos_edge_ids is not None else perm])
 
             # sampling from negative edges
             neg_masks = np.random.choice(neg_edges.size(0), min(edge.size(1), neg_edges.size(0)), replace=False)

--- a/ml_for_road_safety/trainers/supcon_trainer.py
+++ b/ml_for_road_safety/trainers/supcon_trainer.py
@@ -43,6 +43,7 @@ class SupConTrainer(Trainer):
         new_data = monthly_data['data']
         pos_edges, pos_edge_weights, neg_edges = \
             monthly_data['accidents'], monthly_data['accident_counts'], monthly_data['neg_edges']
+        pos_edge_ids = monthly_data.get('pos_edge_ids')
         neg_edge_ids = monthly_data.get('neg_edge_ids')
         
         if pos_edges is None or pos_edges.size(0) < 10:
@@ -67,6 +68,8 @@ class SupConTrainer(Trainer):
         pos_train_edge = pos_edges.to(self.device)
         pos_edge_weights = pos_edge_weights.to(self.device)
         neg_edges = neg_edges.to(self.device)
+        if pos_edge_ids is not None:
+            pos_edge_ids = pos_edge_ids.to(self.device)
         if neg_edge_ids is not None:
             neg_edge_ids = neg_edge_ids.to(self.device)
         total_loss = total_examples = 0
@@ -78,7 +81,7 @@ class SupConTrainer(Trainer):
             features_pos = torch.concat([h[edge[0]], h[edge[1]]], dim=1)
             pos_out = self.predictor(h[edge[0]], h[edge[1]]) \
                 if edge_attr is None else \
-                self.predictor(h[edge[0]], h[edge[1]], edge_attr[perm])
+                self.predictor(h[edge[0]], h[edge[1]], edge_attr[pos_edge_ids[perm] if pos_edge_ids is not None else perm])
 
             # sampling from negative edges
             neg_masks = np.random.choice(neg_edges.size(0), min(edge.size(1), neg_edges.size(0)), replace=False)

--- a/ml_for_road_safety/trainers/trainer.py
+++ b/ml_for_road_safety/trainers/trainer.py
@@ -67,6 +67,7 @@ class Trainer:
         new_data = monthly_data['data']
         pos_edges, pos_edge_weights, neg_edges = \
             monthly_data['accidents'], monthly_data['accident_counts'], monthly_data['neg_edges']
+        pos_edge_ids = monthly_data.get('pos_edge_ids')
         neg_edge_ids = monthly_data.get('neg_edge_ids')
         
         # print(f"len(pos_edges): {len(pos_edges)}, len(pos_edge_weights): {len(pos_edge_weights)}, len(neg_edges): {len(neg_edges)}")
@@ -93,6 +94,8 @@ class Trainer:
         pos_train_edge = pos_edges.to(self.device)
         pos_edge_weights = pos_edge_weights.to(self.device)
         neg_edges = neg_edges.to(self.device)
+        if pos_edge_ids is not None:
+            pos_edge_ids = pos_edge_ids.to(self.device)
         if neg_edge_ids is not None:
             neg_edge_ids = neg_edge_ids.to(self.device)
 
@@ -111,7 +114,7 @@ class Trainer:
             edge = pos_train_edge[perm].t()
             pos_out = self.predictor(h[edge[0]], h[edge[1]]) \
                 if edge_attr is None else \
-                self.predictor(h[edge[0]], h[edge[1]], edge_attr[perm])
+                self.predictor(h[edge[0]], h[edge[1]], edge_attr[pos_edge_ids[perm] if pos_edge_ids is not None else perm])
 
             # sampling from negative edges
             neg_masks = np.random.choice(neg_edges.size(0), min(edge.size(1), neg_edges.size(0)), replace=False)
@@ -188,15 +191,18 @@ class Trainer:
         # predicting
         pos_edge = pos_edges.to(self.device)
         neg_edge = neg_edges.to(self.device)
+        pos_edge_ids = monthly_data.get('pos_edge_ids')
         neg_edge_ids = monthly_data.get('neg_edge_ids')
         if neg_edge_ids is not None:
             neg_edge_ids = neg_edge_ids.to(self.device)
+        if pos_edge_ids is not None:
+            pos_edge_ids = pos_edge_ids.to(self.device)
         pos_preds = []
         for perm in DataLoader(range(pos_edge.size(0)), self.batch_size):
             edge = pos_edge[perm].t()
             preds = self.predictor(h[edge[0]], h[edge[1]]) \
                 if edge_attr is None else \
-                self.predictor(h[edge[0]], h[edge[1]], edge_attr[perm])
+                self.predictor(h[edge[0]], h[edge[1]], edge_attr[pos_edge_ids[perm] if pos_edge_ids is not None else perm])
             pos_preds += [preds.squeeze().cpu()] 
         pos_preds = torch.cat(pos_preds, dim=0)
 


### PR DESCRIPTION
## Summary
- correct indexing for positive edge attributes in trainer implementations
- propagate `pos_edge_ids` through trainers to correctly select edge features

## Testing
- `python -m py_compile ml_for_road_safety/trainers/trainer.py ml_for_road_safety/trainers/sam_trainer.py ml_for_road_safety/trainers/supcon_trainer.py`

------
https://chatgpt.com/codex/tasks/task_e_68541d17b9e8832e9c2fd410e0e6bcf9